### PR TITLE
Update repo references to OpenNeptune3D instead of halfmanbear

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ When you access the eMMC, note the PCB / Main-board's version number, which will
 
 ### Installation:
 
-- See the [Releases](https://github.com/halfmanbear/OpenNept4une/releases/) section for the latest pre-configured OpenNept4une eMMC Image. Flash with balenaEtcher or dd.
+- See the [Releases](https://github.com/OpenNeptune3D/OpenNept4une/releases/) section for the latest pre-configured OpenNept4une eMMC Image. Flash with balenaEtcher or dd.
 - Recommended to Back-Up original eMMC beforehand.
 - Run the following startup scripts with Ethernet connected (as user mks)
   
@@ -168,7 +168,7 @@ sudo armbian-config
 - Download the latest Official Release [OrcaSlicer](https://github.com/SoftFever/OrcaSlicer/releases/) 
 - Configure Orca defaults for your machines model before import.
 - Check/confirm Bambu Network Engine install
-- Download the latest [OrcaSlicer Profiles](https://github.com/halfmanbear/OpenNept4une/tree/main/orca-profiles)
+- Download the latest [OrcaSlicer Profiles](https://github.com/OpenNeptune3D/OpenNept4une/tree/main/orca-profiles)
 - In OrcaSlicer click [File > Import > Import Configs...]
 
 

--- a/display/display.py
+++ b/display/display.py
@@ -274,7 +274,7 @@ class DisplayController:
         elif current_page == PAGE_SETTINGS_ABOUT:
             self._write('fill 0,400,320,60,' + str(BACKGROUND_GRAY))
             self._write('xstr 0,400,320,30,1,65535,' + str(BACKGROUND_GRAY) + ',1,1,1,"OpenNept4une"')
-            self._write('xstr 0,430,320,30,2,GRAY,' + str(BACKGROUND_GRAY) + ',1,1,1,"github.com/halfmanbear/OpenNept4une"')
+            self._write('xstr 0,430,320,30,2,GRAY,' + str(BACKGROUND_GRAY) + ',1,1,1,"github.com/OpenNeptune3D/OpenNept4une"')
         elif current_page == PAGE_PRINTING:
             self._write("printvalue.xcen=0")
             self._write("move printvalue,13,267,13,267,0,10")

--- a/img-config/base_image_configuration.sh
+++ b/img-config/base_image_configuration.sh
@@ -28,11 +28,11 @@ fi
 
 # Hardcoded list of GitHub raw links paired with filenames
 declare -A LINKS_AND_NAMES=(
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/printer.cfg"]="printer.cfg"
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/moonraker.conf"]="moonraker.conf"
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/KAMP_Settings.cfg"]="KAMP_Settings.cfg"
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/adxl.cfg"]="adxl.cfg"  
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/crowsnest.conf"]="crowsnest.conf"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/printer.cfg"]="printer.cfg"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/moonraker.conf"]="moonraker.conf"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/KAMP_Settings.cfg"]="KAMP_Settings.cfg"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/adxl.cfg"]="adxl.cfg"  
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/crowsnest.conf"]="crowsnest.conf"
 )
 
 # Destination directory
@@ -50,7 +50,7 @@ for link in "${!LINKS_AND_NAMES[@]}"; do
 done
 
 # Fluidd DB transfer
-SHARE_LINK="https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/data.mdb"
+SHARE_LINK="https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/data.mdb"
 
 DESTINATION_DIR="$HOME/printer_data/database"
 DESTINATION_FILE="${DESTINATION_DIR}/data.mdb"

--- a/img-config/de_elegoo_cleanser.sh
+++ b/img-config/de_elegoo_cleanser.sh
@@ -56,11 +56,11 @@ fi
 
 # Hardcoded list of GitHub raw links paired with filenames
 declare -A LINKS_AND_NAMES=(
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/printer.cfg"]="printer.cfg"
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/moonraker.conf"]="moonraker.conf"
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/KAMP_Settings.cfg"]="KAMP_Settings.cfg"
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/adxl.cfg"]="adxl.cfg"  
-    ["https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/crowsnest.conf"]="crowsnest.conf"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/printer.cfg"]="printer.cfg"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/moonraker.conf"]="moonraker.conf"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/KAMP_Settings.cfg"]="KAMP_Settings.cfg"
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/adxl.cfg"]="adxl.cfg"  
+    ["https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/crowsnest.conf"]="crowsnest.conf"
 )
 
 # Destination directory
@@ -78,7 +78,7 @@ for link in "${!LINKS_AND_NAMES[@]}"; do
 done
 
 # Fluidd DB transfer
-SHARE_LINK="https://raw.githubusercontent.com/halfmanbear/OpenNept4une/main/img-config/printer-data/data.mdb"
+SHARE_LINK="https://raw.githubusercontent.com/OpenNeptune3D/OpenNept4une/main/img-config/printer-data/data.mdb"
 
 DESTINATION_DIR="$HOME/printer_data/database"
 DESTINATION_FILE="${DESTINATION_DIR}/data.mdb"

--- a/mcu-firmware/README.md
+++ b/mcu-firmware/README.md
@@ -17,7 +17,7 @@
   
 2. **MicroSD Preparation:**
    - Format a MicroSD card to FAT32
-   - Download this firmware file [X_4.bin](https://github.com/halfmanbear/OpenNept4une/raw/main/mcu-firmware/X_4.bin). Alternatively, compile the latest (INFO further down #Compile Latest klipper.bin)
+   - Download this firmware file [X_4.bin](https://github.com/OpenNeptune3D/OpenNept4une/raw/main/mcu-firmware/X_4.bin). Alternatively, compile the latest (INFO further down #Compile Latest klipper.bin)
    - Copy the file to the root of the MicroSD
    - Models manufactured after ~20-7-2023 (23720 on the barcode) may require X_4.bin to be re-named to elegoo_k1.bin
    - Safely Eject the MicroSD


### PR DESCRIPTION
To be consistent with the new org 😄

I know the display stack is being moved to another repo (which makes a lot of sense), but the ones currently using it will also get to see the new URL within the display.