### PR TITLE
Moonraker Update Manager entry Fix 

### DIFF
--- a/OpenNept4une.sh
+++ b/OpenNept4une.sh
@@ -520,8 +520,9 @@ run_install_screen_service_with_setup() {
 initialize_display_connector() {
     if [ ! -d "${HOME}/display_connector" ]; then
         git clone -b "$current_branch" "${DISPLAY_CONNECTOR_REPO}" "${DISPLAY_CONNECTOR_DIR}"
-        echo -e"${G}Initialized repository for Touch-Screen Display Service.${NC}"
+        echo -e "${G}Initialized repository for Touch-Screen Display Service.${NC}"
     fi
+    moonraker_update_manager "display"
 }
 
 reboot_system() {


### PR DESCRIPTION
When migrating or installing the display service (for the first time) the script currently doesn't call;

moonraker_update_manager "display"

The moonraker.conf will only be updated when OpenNept4une.sh is rerun (as this is part of the update checks).

This pull request adds another call to (moonraker_update_manager "display") within the following function.

initialize_display_connector()

This should apply the moonraker entry correctly when someone migrates the old display dir or if the service is installed for the first time.

