### PR TITLE
Stealthchop fix n4max-printer.cfg  

### DIFF
--- a/printer-confs/n4max/n4max-printer.cfg
+++ b/printer-confs/n4max/n4max-printer.cfg
@@ -131,7 +131,7 @@ uart_pin: PD2
 run_current: 1.4
 #hold_current: 1.2
 interpolate: True
-stealthchop_threshold: 0
+stealthchop_threshold: 999999
 driver_SGTHRS:110
 diag_pin:^PB8
 


### PR DESCRIPTION
Users printer.cfg I used for the max had the stealthchop_threshold for y opposite to x.
This has now been fixed