### PR TITLE
feat: Dynamic PID Tuning Temperatures

### DIFF
--- a/printer-confs/n4/n4-0.8-printer.cfg
+++ b/printer-confs/n4/n4-0.8-printer.cfg
@@ -564,24 +564,27 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(215) %}
   G28
   M106 S255
-  PID_CALIBRATE HEATER=extruder TARGET=215
+  PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
 [gcode_macro PID_Tune_Inner_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 
 [gcode_macro PID_Tune_Outer_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 

--- a/printer-confs/n4/n4-0.8-printer.cfg
+++ b/printer-confs/n4/n4-0.8-printer.cfg
@@ -570,16 +570,7 @@ gcode:
   PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
-[gcode_macro PID_Tune_Inner_BED]
-gcode:
-  {% set temperature = params.TEMPERATURE|default(60) %}
-  G28
-  M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
-  SAVE_CONFIG
-  
-
-[gcode_macro PID_Tune_Outer_BED]
+[gcode_macro PID_Tune_BED]
 gcode:
   {% set temperature = params.TEMPERATURE|default(60) %}
   G28

--- a/printer-confs/n4/n4-0.8-printer.cfg
+++ b/printer-confs/n4/n4-0.8-printer.cfg
@@ -564,7 +564,7 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
-  {% set temperature = params.TEMPERATURE|default(215) %}
+  {% set temperature = params.TEMPERATURE|default(210) %}
   G28
   M106 S255
   PID_CALIBRATE HEATER=extruder TARGET={temperature}

--- a/printer-confs/n4/n4-1.2-printer.cfg
+++ b/printer-confs/n4/n4-1.2-printer.cfg
@@ -564,24 +564,27 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(215) %}
   G28
   M106 S255
-  PID_CALIBRATE HEATER=extruder TARGET=215
+  PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
 [gcode_macro PID_Tune_Inner_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 
 [gcode_macro PID_Tune_Outer_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 

--- a/printer-confs/n4/n4-1.2-printer.cfg
+++ b/printer-confs/n4/n4-1.2-printer.cfg
@@ -570,16 +570,7 @@ gcode:
   PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
-[gcode_macro PID_Tune_Inner_BED]
-gcode:
-  {% set temperature = params.TEMPERATURE|default(60) %}
-  G28
-  M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
-  SAVE_CONFIG
-  
-
-[gcode_macro PID_Tune_Outer_BED]
+[gcode_macro PID_Tune_BED]
 gcode:
   {% set temperature = params.TEMPERATURE|default(60) %}
   G28

--- a/printer-confs/n4/n4-1.2-printer.cfg
+++ b/printer-confs/n4/n4-1.2-printer.cfg
@@ -564,7 +564,7 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
-  {% set temperature = params.TEMPERATURE|default(215) %}
+  {% set temperature = params.TEMPERATURE|default(210) %}
   G28
   M106 S255
   PID_CALIBRATE HEATER=extruder TARGET={temperature}

--- a/printer-confs/n4max/n4max-printer.cfg
+++ b/printer-confs/n4max/n4max-printer.cfg
@@ -601,16 +601,7 @@ gcode:
   PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
-[gcode_macro PID_Tune_Inner_BED]
-gcode:
-  {% set temperature = params.TEMPERATURE|default(60) %}
-  G28
-  M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
-  SAVE_CONFIG
-  
-
-[gcode_macro PID_Tune_Outer_BED]
+[gcode_macro PID_Tune_BED]
 gcode:
   {% set temperature = params.TEMPERATURE|default(60) %}
   G28

--- a/printer-confs/n4max/n4max-printer.cfg
+++ b/printer-confs/n4max/n4max-printer.cfg
@@ -595,7 +595,7 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
-  {% set temperature = params.TEMPERATURE|default(215) %}
+  {% set temperature = params.TEMPERATURE|default(210) %}
   G28
   M106 S255
   PID_CALIBRATE HEATER=extruder TARGET={temperature}

--- a/printer-confs/n4max/n4max-printer.cfg
+++ b/printer-confs/n4max/n4max-printer.cfg
@@ -595,24 +595,27 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(215) %}
   G28
   M106 S255
-  PID_CALIBRATE HEATER=extruder TARGET=215
+  PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
 [gcode_macro PID_Tune_Inner_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 
 [gcode_macro PID_Tune_Outer_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 

--- a/printer-confs/n4plus/n4plus-printer.cfg
+++ b/printer-confs/n4plus/n4plus-printer.cfg
@@ -574,7 +574,7 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
-  {% set temperature = params.TEMPERATURE|default(215) %}
+  {% set temperature = params.TEMPERATURE|default(210) %}
   G28
   M106 S255
   PID_CALIBRATE HEATER=extruder TARGET={temperature}

--- a/printer-confs/n4plus/n4plus-printer.cfg
+++ b/printer-confs/n4plus/n4plus-printer.cfg
@@ -580,7 +580,7 @@ gcode:
   PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
-[gcode_macro PID_Tune_Inner_BED]
+[gcode_macro PID_Tune_BED]
 gcode:
   {% set temperature = params.TEMPERATURE|default(60) %}
   G28

--- a/printer-confs/n4plus/n4plus-printer.cfg
+++ b/printer-confs/n4plus/n4plus-printer.cfg
@@ -574,16 +574,18 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(215) %}
   G28
   M106 S255
-  PID_CALIBRATE HEATER=extruder TARGET=215
+  PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
 [gcode_macro PID_Tune_Inner_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
 
 

--- a/printer-confs/n4pro/n4pro-0.8-printer.cfg
+++ b/printer-confs/n4pro/n4pro-0.8-printer.cfg
@@ -585,25 +585,28 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(215) %}
   G28
   M106 S255
-  PID_CALIBRATE HEATER=extruder TARGET=215
+  PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
 [gcode_macro PID_Tune_Inner_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 
 [gcode_macro PID_Tune_Outer_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=60 	;Heats Inner Zone to 60c at same time for better tuning 
-  PID_CALIBRATE HEATER=heater_bed_outer TARGET=60
+  SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET={temperature} 	;Heats Inner Zone at the same time for better tuning 
+  PID_CALIBRATE HEATER=heater_bed_outer TARGET={temperature}
   SAVE_CONFIG
   
 

--- a/printer-confs/n4pro/n4pro-0.8-printer.cfg
+++ b/printer-confs/n4pro/n4pro-0.8-printer.cfg
@@ -585,7 +585,7 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
-  {% set temperature = params.TEMPERATURE|default(215) %}
+  {% set temperature = params.TEMPERATURE|default(210) %}
   G28
   M106 S255
   PID_CALIBRATE HEATER=extruder TARGET={temperature}

--- a/printer-confs/n4pro/n4pro-1.2-printer.cfg
+++ b/printer-confs/n4pro/n4pro-1.2-printer.cfg
@@ -586,7 +586,7 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
-  {% set temperature = params.TEMPERATURE|default(215) %}
+  {% set temperature = params.TEMPERATURE|default(210) %}
   G28
   M106 S255
   PID_CALIBRATE HEATER=extruder TARGET={temperature}

--- a/printer-confs/n4pro/n4pro-1.2-printer.cfg
+++ b/printer-confs/n4pro/n4pro-1.2-printer.cfg
@@ -586,25 +586,28 @@ gcode:
 
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(215) %}
   G28
   M106 S255
-  PID_CALIBRATE HEATER=extruder TARGET=215
+  PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
 
 [gcode_macro PID_Tune_Inner_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
+  PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG
   
 
 [gcode_macro PID_Tune_Outer_BED]
 gcode:
+  {% set temperature = params.TEMPERATURE|default(60) %}
   G28
   M106 S255 ;Sets Print Fans to 100%
-  SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=60 	;Heats Inner Zone to 60c at same time for better tuning 
-  PID_CALIBRATE HEATER=heater_bed_outer TARGET=60
+  SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET={temperature} 	;Heats Inner Zone at the same time for better tuning 
+  PID_CALIBRATE HEATER=heater_bed_outer TARGET={temperature}
   SAVE_CONFIG
   
 


### PR DESCRIPTION
I'm just starting to play with PETG, and the bed and extruder temps are different from the stock PLA settings, so I went through the PID tuning process with this. This makes it easier to pick a target temperature through Fluidd/Mainsail/KlipperScreen.

Also, standardize `PID_Tune_BED` for non-Pro printers, removing unnecessary `PID_Tune_Outer_BED` macros.

Setting Extruder PID default temp to 210 to match the OrcaSlicer profile for PLA.

Targetting `dev`.