### PR TITLE
Removed centre reference "screw" from max and plus

### DIFF
--- a/printer-confs/n4/section_screw_tilt.cfg
+++ b/printer-confs/n4/section_screw_tilt.cfg
@@ -1,11 +1,11 @@
-screw1: 56.75, 12.05  ; original was (32.5, 32.5)
-screw1_name: front left screw
-screw2: 226.75, 12.05  ; original was (202.5, 32.5)
-screw2_name: front right screw
-screw3: 226.75, 182.05  ; original was (202.5, 202.5)
-screw3_name: rear right screw
-screw4: 56.75, 182.05  ; original was (32.5, 202.5)
-screw4_name: rear left screw
+screw1: 56.75, 182.05  
+screw1_name: rear left screw
+screw2: 56.75, 12.05  
+screw2_name: front left screw
+screw3: 226.75, 12.05  
+screw3_name: front right screw
+screw4: 226.75, 182.05  
+screw4_name: rear right screw
 horizontal_move_z: 5
 speed: 150
 screw_thread: CW-M4

--- a/printer-confs/n4max/section_screw_tilt.cfg
+++ b/printer-confs/n4max/section_screw_tilt.cfg
@@ -1,17 +1,15 @@
-screw1: 239.75,194.55
-screw1_name: center point
-screw4: 56.75,367.05
-screw4_name: rear left screw
-screw3: 56.75,189.05
-screw3_name: center left screw
-screw2: 56.75,12.05
-screw2_name: front left screw
-screw7: 409.75,12.05
-screw7_name: front right screw
-screw6: 409.75,189.05
-screw6_name: center right screw
-screw5: 409.75,367.05
-screw5_name: rear right screw 
+screw1: 56.75,367.05
+screw1_name: rear left screw
+screw2: 56.75,189.05
+screw2_name: center left screw
+screw3: 56.75,12.05
+screw3_name: front left screw
+screw4: 409.75,12.05
+screw4_name: front right screw
+screw5: 409.75,189.05
+screw5_name: center right screw
+screw6: 409.75,367.05
+screw6_name: rear right screw 
 horizontal_move_z: 5
 speed: 150
 screw_thread: CW-M4

--- a/printer-confs/n4plus/section_screw_tilt.cfg
+++ b/printer-confs/n4plus/section_screw_tilt.cfg
@@ -1,17 +1,15 @@
-screw1: 184.50, 144.50  
-screw1_name: center point
-screw2: 57, 277.5 
-screw2_name: rear left screw
-screw3: 57, 144.5   
-screw3_name: center left screw
-screw4: 57, 11.5  
-screw4_name: front left screw
-screw5: 312, 11.5 
-screw5_name: front right screw
-screw6: 312, 144.5 
-screw6_name: center right screw
-screw7: 312, 277.5   
-screw7_name: rear right screw
+screw1: 57, 277.5 
+screw1_name: rear left screw
+screw2: 57, 144.5   
+screw2_name: center left screw
+screw3: 57, 11.5  
+screw3_name: front left screw
+screw4: 312, 11.5 
+screw4_name: front right screw
+screw5: 312, 144.5 
+screw5_name: center right screw
+screw6: 312, 277.5   
+screw6_name: rear right screw
 horizontal_move_z: 5
 speed: 150
 screw_thread: CW-M4

--- a/printer-confs/n4pro/section_screw_tilt.cfg
+++ b/printer-confs/n4pro/section_screw_tilt.cfg
@@ -1,11 +1,11 @@
-screw1: 56.75, 12.05  
-screw1_name: front left screw
-screw2: 226.75, 12.05  
-screw2_name: front right screw
-screw3: 226.75, 182.05  
-screw3_name: rear right screw
-screw4: 56.75, 182.05  
-screw4_name: rear left screw
+screw1: 56.75, 182.05  
+screw1_name: rear left screw
+screw2: 56.75, 12.05  
+screw2_name: front left screw
+screw3: 226.75, 12.05  
+screw3_name: front right screw
+screw4: 226.75, 182.05  
+screw4_name: rear right screw
 horizontal_move_z: 5
 speed: 150
 screw_thread: CW-M4


### PR DESCRIPTION
Reorder every machine to start screws tilt adjust from rear left (base fixed) then in order around the perimeter counter clockwise. 

Didn't make sense to have the front left screw the one you don't adjust. So moved it to the rear.

