### PR TITLE
Improved N4Plus & Max [screws_tilt_adjust]

### DIFF
--- a/printer-confs/n4max/section_screw_tilt.cfg
+++ b/printer-confs/n4max/section_screw_tilt.cfg
@@ -1,4 +1,3 @@
-[screws_tilt_adjust]
 screw1: 239.25,194.55 
 screw1_name: middle of bed (reference non-adjust)
 screw2: 239.25,254.55  

--- a/printer-confs/n4max/section_screw_tilt.cfg
+++ b/printer-confs/n4max/section_screw_tilt.cfg
@@ -1,21 +1,19 @@
-screw1: 239.25,194.55 
-screw1_name: middle of bed (reference non-adjust)
-screw2: 239.25,254.55  
-screw2_name: middle rear bed (shim adjust)
-screw3: 239.25,134.55 
-screw3_name: middle front bed (shim adjust)
-screw4: 56.75,377.05           
-screw4_name: rear left screw
-screw5: 56.75,194.55           
-screw5_name: center left screw
-screw6: 56.75,12.05            
-screw6_name: front left screw
-screw7: 421.75,12.05
-screw7_name: front right screw
-screw8: 421.75,194.55
-screw8_name: center right screw
-screw9: 421.75,377.05
-screw9_name: rear right screw
+screw1: 239.25,254.55  
+screw1_name: middle-rear bed mount (shim adjust)
+screw2: 239.25,134.55 
+screw2_name: middle-front bed mount (shim adjust)
+screw3: 56.75,377.05           
+screw3_name: rear left screw
+screw4: 56.75,194.55           
+screw4_name: center left screw
+screw5: 56.75,12.05            
+screw5_name: front left screw
+screw6: 421.75,12.05
+screw6_name: front right screw
+screw7: 421.75,194.55
+screw7_name: center right screw
+screw8: 421.75,377.05
+screw8_name: rear right screw
 horizontal_move_z: 5
 speed: 150
 screw_thread: CW-M4

--- a/printer-confs/n4max/section_screw_tilt.cfg
+++ b/printer-confs/n4max/section_screw_tilt.cfg
@@ -1,15 +1,22 @@
-screw1: 56.75,367.05
-screw1_name: rear left screw
-screw2: 56.75,189.05
-screw2_name: center left screw
-screw3: 56.75,12.05
-screw3_name: front left screw
-screw4: 409.75,12.05
-screw4_name: front right screw
-screw5: 409.75,189.05
-screw5_name: center right screw
-screw6: 409.75,367.05
-screw6_name: rear right screw 
+[screws_tilt_adjust]
+screw1: 239.25,194.55 
+screw1_name: middle of bed (reference non-adjust)
+screw2: 239.25,254.55  
+screw2_name: middle rear bed (shim adjust)
+screw3: 239.25,134.55 
+screw3_name: middle front bed (shim adjust)
+screw4: 56.75,377.05           
+screw4_name: rear left screw
+screw5: 56.75,194.55           
+screw5_name: center left screw
+screw6: 56.75,12.05            
+screw6_name: front left screw
+screw7: 421.75,12.05
+screw7_name: front right screw
+screw8: 421.75,194.55
+screw8_name: center right screw
+screw9: 421.75,377.05
+screw9_name: rear right screw
 horizontal_move_z: 5
 speed: 150
 screw_thread: CW-M4

--- a/printer-confs/n4plus/section_screw_tilt.cfg
+++ b/printer-confs/n4plus/section_screw_tilt.cfg
@@ -1,15 +1,18 @@
-screw1: 57, 277.5 
-screw1_name: rear left screw
-screw2: 57, 144.5   
-screw2_name: center left screw
-screw3: 57, 11.5  
-screw3_name: front left screw
-screw4: 312, 11.5 
-screw4_name: front right screw
-screw5: 312, 144.5 
-screw5_name: center right screw
-screw6: 312, 277.5   
-screw6_name: rear right screw
-horizontal_move_z: 5
-speed: 150
-screw_thread: CW-M4
+screw1: 189.25,144.55
+screw1_name: middle of bed (reference non-adjust)
+screw2: 189.25,189.55
+screw2_name: middle rear bed (shim adjust)
+screw3: 189.25,99.55
+screw3_name: middle front bed (shim adjust)
+screw4: 56.75,277.05         
+screw4_name: rear left screw
+screw5: 56.75,144.55        
+screw5_name: center left screw
+screw6: 56.75,12.05            
+screw6_name: front left screw
+screw7: 321.75,12.05
+screw7_name: front right screw
+screw8: 321.75,144.55
+screw8_name: center right screw
+screw9: 321.75,277.05
+screw9_name: rear right screw

--- a/printer-confs/n4plus/section_screw_tilt.cfg
+++ b/printer-confs/n4plus/section_screw_tilt.cfg
@@ -1,21 +1,19 @@
-screw1: 189.25,144.55
-screw1_name: middle of bed (reference non-adjust)
-screw2: 189.25,189.55
-screw2_name: middle rear bed (shim adjust)
-screw3: 189.25,99.55
-screw3_name: middle front bed (shim adjust)
-screw4: 56.75,277.05         
-screw4_name: rear left screw
-screw5: 56.75,144.55        
-screw5_name: center left screw
-screw6: 56.75,12.05            
-screw6_name: front left screw
-screw7: 321.75,12.05
-screw7_name: front right screw
-screw8: 321.75,144.55
-screw8_name: center right screw
-screw9: 321.75,277.05
-screw9_name: rear right screw
+screw1: 189.25,189.55
+screw1_name: middle-rear bed mount (shim adjust)
+screw2: 189.25,99.55
+screw2_name: middle-front bed mount (shim adjust)
+screw3: 56.75,277.05         
+screw3_name: rear left screw
+screw4: 56.75,144.55        
+screw4_name: center left screw
+screw5: 56.75,12.05            
+screw5_name: front left screw
+screw6: 321.75,12.05
+screw6_name: front right screw
+screw7: 321.75,144.55
+screw7_name: center right screw
+screw8: 321.75,277.05
+screw8_name: rear right screw
 horizontal_move_z: 5
 speed: 150
 screw_thread: CW-M4

--- a/printer-confs/n4plus/section_screw_tilt.cfg
+++ b/printer-confs/n4plus/section_screw_tilt.cfg
@@ -16,3 +16,6 @@ screw8: 321.75,144.55
 screw8_name: center right screw
 screw9: 321.75,277.05
 screw9_name: rear right screw
+horizontal_move_z: 5
+speed: 150
+screw_thread: CW-M4


### PR DESCRIPTION
After discovering the two middle bed mount shims on the Plus & Max (aligned along the x-axis), I have added the two "middle" bed sim coordinates and made the middle-rear shim point as the base. 

This will be cross-referenced with the middle-front shim location before proceeding with the adjustments of the perimeter screws.

This should help greatly with ensuring the bed shims are level (or both not too high or low) before continuing with the perimeter screws.

I have also improved the screw location coordinates to be more accurate.