### PR TITLE
Optimize homing in print start macro

### DIFF
--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -60,7 +60,6 @@ gcode:
     G92 E0 
     G90                       ; Use absolute coordinates
     BED_MESH_CLEAR
-    G28     
   
     {% set BED_TEMP = params.BED_TEMP|default(60)|float %}
     {% set BED_MESH = params.BED_MESH|default('adaptive')|string %} ; One of: adaptive (default), full, default (or any other value as the bed mesh profile name), none
@@ -71,6 +70,7 @@ gcode:
     {{ start_bed_setup }}
 
     SET_BED_TEMPERATURE TARGET={BED_TEMP}                           ; Heat Bed to target temp
+    G28     
     BED_TEMPERATURE_WAIT MINIMUM={BED_TEMP-2} MAXIMUM={BED_TEMP+4}  ; Waits until the bed reaches close to target
     
     {% if BED_MESH == 'full' %}


### PR DESCRIPTION
Homing takes some time.
If we home after setting the temperatures we save the homing time for bed heating time.