### PR TITLE
Adds the possibility to wait for the bed to stabilize

### DIFF
--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -66,6 +66,7 @@ gcode:
     BED_MESH_CLEAR    
   
     {% set BED_TEMP = params.BED_TEMP|default(60)|float %}
+    {% set BED_HEAT_SOAK_MINUTES = params.BED_HEAT_SOAK_MINUTES|default(0)|float %}
     {% set BED_MESH = params.BED_MESH|default('adaptive')|string %} ; One of: adaptive (default), full, default (or any other value as the bed mesh profile name), none
     {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP|default(200)|float %}
 
@@ -73,6 +74,10 @@ gcode:
 
     SET_BED_TEMPERATURE TARGET={BED_TEMP}                           ; Heat Bed to target temp
     BED_TEMPERATURE_WAIT MINIMUM={BED_TEMP-2} MAXIMUM={BED_TEMP+4}  ; Waits until the bed reaches close to target
+    {% if BED_HEAT_SOAK_MINUTES > 0 %}
+    RESPOND MSG="Waiting {BED_HEAT_SOAK_MINUTES} minutes for the bed to settle."
+    G4 P{BED_HEAT_SOAK_MINUTES * 60000}
+    {% endif %}
 
     G28
     


### PR DESCRIPTION
It seems the beds need like 30 min until they are stable and do not expand anymore, after heating them up.
I add another paramter to PRINT_START to be able to wait for a some seconds before starting the print.
PRINT_START can be called like this to wait for 30 minutes: PRINT_START BED_STABILIZE_WAIT=1800000 BED_TEMP=...