### PR TITLE
Add conditional G28 macro.

### DIFF
--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -74,7 +74,7 @@ gcode:
     SET_BED_TEMPERATURE TARGET={BED_TEMP}                           ; Heat Bed to target temp
     BED_TEMPERATURE_WAIT MINIMUM={BED_TEMP-2} MAXIMUM={BED_TEMP+4}  ; Waits until the bed reaches close to target
 
-    G28
+    CG28
     
     {% if BED_MESH == 'full' %}
     BED_MESH_CALIBRATE
@@ -499,6 +499,13 @@ max_temp: 85
 #   Homing & Levelling Config/Macros
 #############################################################################
 
+[gcode_macro CG28]
+gcode:
+  {% if "xyz" not in printer.toolhead.homed_axes %}
+      G28
+  {% else %}
+  {% endif %}
+  
 [safe_z_home]
 home_xy_position: {{ safe_z_home_xy_position }}
 speed: 100
@@ -512,7 +519,7 @@ calibrate_y: {{ axis_twist_y }}
 
 [gcode_macro Axis_Twist_Comp_Tune]
 gcode:    
-      G28
+      CG28
       AXIS_TWIST_COMPENSATION_CALIBRATE
 
 [screws_tilt_adjust]
@@ -523,12 +530,12 @@ gcode:
       BED_MESH_CLEAR
       SET_BED_TEMPERATURE TARGET=60
       BED_TEMPERATURE_WAIT MINIMUM=58 MAXIMUM=65
-      G28
+      CG28
       SCREWS_TILT_CALCULATE
 
 [gcode_macro Calibrate_Probe_Z_Offset]
 gcode:
-      G28
+      CG28
       PROBE_CALIBRATE
       
 [gcode_macro Auto_Full_Bed_Level]
@@ -537,7 +544,7 @@ gcode:
       BED_MESH_CLEAR
       SET_BED_TEMPERATURE TARGET=60
       BED_TEMPERATURE_WAIT MINIMUM=58 MAXIMUM=65
-      G28
+      CG28
       BED_MESH_CALIBRATE
 
 #############################################################################
@@ -547,7 +554,7 @@ gcode:
 [gcode_macro PID_Tune_EXTRUDER]
 gcode:
   {% set temperature = params.TEMPERATURE|default(210) %}
-  G28
+  CG28
   M106 S255
   PID_CALIBRATE HEATER=extruder TARGET={temperature}
   SAVE_CONFIG
@@ -555,7 +562,7 @@ gcode:
 [gcode_macro PID_Tune_BED]
 gcode:
   {% set temperature = params.TEMPERATURE|default(60) %}
-  G28
+  CG28
   M106 S255 ;Sets Print Fans to 100%
   PID_CALIBRATE HEATER=heater_bed TARGET={temperature}
   SAVE_CONFIG


### PR DESCRIPTION
Klipper keeps track of the state of the homed axes in [toolhead status](https://www.klipper3d.org/Status_Reference.html#toolhead).

This pull request adds a macro called `CG28` that only runs a `G28` if all three axes are not already in the toolhead `homed_axes`, reducing excessive homing calls. All existing G28 calls in `base.cfg` have been replaced with the new `CG28`.

I have been leveraging this macro on my 4 Pro for about 8 months now with no issues.