### PR TITLE
Heat both beds on Neptune 4 Pro, if bed is particularly hot

### DIFF
--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -58,6 +58,7 @@ timeout: 2100                  ; 35min idle timeout (when not paused or printing
 
 [gcode_macro PRINT_START]   
 {{ variable_small_print }}
+{{ variable_force_outer_bed_heater }}
 gcode:
     Frame_Light_ON
     Part_Light_ON

--- a/printer-confs/n4pro/n4pro.cfg
+++ b/printer-confs/n4pro/n4pro.cfg
@@ -51,4 +51,7 @@ bed_max_error=120
 bed_gain_time=120
 bed_heat_gain=1
 
+outer_bed_force_activation_temp=90 ; the temperature both the inner & outer heaters are required even for small prints
+
 variable_small_print=variable_small_print: False
+variable_force_outer_bed_heater=variable_force_outer_bed_heater: False

--- a/printer-confs/n4pro/section_extra_heating.cfg
+++ b/printer-confs/n4pro/section_extra_heating.cfg
@@ -24,7 +24,7 @@ heating_gain: 1                     ; heating gain
 [gcode_macro SET_BED_TEMPERATURE]   ; macros for innner & outer bed temperature depending on the print size
 gcode:
     SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET={params.TARGET}
-    {% if not printer["gcode_macro PRINT_START"].small_print %}
+    {% if printer["gcode_macro PRINT_START"].force_outer_bed_heater or not printer["gcode_macro PRINT_START"].small_print %}
       SET_HEATER_TEMPERATURE HEATER=heater_bed_outer TARGET={params.TARGET}
     {% endif %}
 
@@ -32,17 +32,17 @@ gcode:
 gcode:
     {% if params.MINIMUM is defined and params.MAXIMUM is defined %}
       TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={params.MINIMUM} MAXIMUM={params.MAXIMUM}
-      {% if not printer["gcode_macro PRINT_START"].small_print %}
+      {% if printer["gcode_macro PRINT_START"].force_outer_bed_heater or not printer["gcode_macro PRINT_START"].small_print %}
         TEMPERATURE_WAIT SENSOR="heater_generic heater_bed_outer" MINIMUM={params.MINIMUM} MAXIMUM={params.MAXIMUM}
       {% endif %}
     {% elif params.MINIMUM is defined %}
       TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={params.MINIMUM}
-      {% if not printer["gcode_macro PRINT_START"].small_print %}
+      {% if printer["gcode_macro PRINT_START"].force_outer_bed_heater or not printer["gcode_macro PRINT_START"].small_print %}
         TEMPERATURE_WAIT SENSOR="heater_generic heater_bed_outer" MINIMUM={params.MINIMUM}
       {% endif %}
     {% elif params.MAXIMUM is defined %}
       TEMPERATURE_WAIT SENSOR=heater_bed MAXIMUM={params.MAXIMUM}
-      {% if not printer["gcode_macro PRINT_START"].small_print %}
+      {% if printer["gcode_macro PRINT_START"].force_outer_bed_heater or not printer["gcode_macro PRINT_START"].small_print %}
         TEMPERATURE_WAIT SENSOR="heater_generic heater_bed_outer" MAXIMUM={params.MAXIMUM}
       {% endif %}
     {% else %}

--- a/printer-confs/n4pro/section_start_bed_setup.cfg
+++ b/printer-confs/n4pro/section_start_bed_setup.cfg
@@ -15,3 +15,11 @@
     {% else %}                                                               ; print extends beyond center, set temperatures for both beds
       SET_GCODE_VARIABLE MACRO=PRINT_START VARIABLE=small_print VALUE=False 
     {% endif %}
+
+    # If the bed is particularly hot, use both heaters in any case, wether it is a small print or not
+    {% if BED_TEMP >= outer_bed_force_activation_temp %}
+      SET_GCODE_VARIABLE MACRO=PRINT_START VARIABLE=force_outer_bed_heater VALUE=True
+    {% else %}
+      # Print extends beyond center, set temperatures for both beds
+      SET_GCODE_VARIABLE MACRO=PRINT_START VARIABLE=force_outer_bed_heater VALUE=False
+    {% endif %}


### PR DESCRIPTION
For small prints on Neptune 4 Pro only the bed center is heated, however if the bed is heated particularly hot (e.g. to 100 C / 210 F for ABS), the central heater struggles to provide the sufficient heat. In such cases, both heaters are required, even for small prints.