### PR TITLE
Increase load/unload distance to prevent needing multiple presses

### DIFF
--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -228,8 +228,8 @@ gcode:
 
 [gcode_macro LOAD_FILAMENT]
 variable_prev_temp: 220
-variable_load_distance:  90
-variable_purge_distance:  30
+variable_load_distance:  25
+variable_purge_distance:  75
 gcode:
   {% set target_temp = prev_temp|int if prev_temp >= 200 else 220 %}
   SET_HEATER_TEMPERATURE HEATER=extruder TARGET={target_temp}
@@ -245,7 +245,7 @@ gcode:
 
 [gcode_macro UNLOAD_FILAMENT]
 variable_prev_temp: 220
-variable_unload_distance:  90
+variable_unload_distance:  75
 variable_purge_distance:  15
 gcode:
   {% set target_temp = prev_temp|int if prev_temp >= 200 else 220 %}

--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -228,7 +228,7 @@ gcode:
 
 [gcode_macro LOAD_FILAMENT]
 variable_prev_temp: 220
-variable_load_distance:  25
+variable_load_distance:  90
 variable_purge_distance:  30
 gcode:
   {% set target_temp = prev_temp|int if prev_temp >= 200 else 220 %}
@@ -245,7 +245,7 @@ gcode:
 
 [gcode_macro UNLOAD_FILAMENT]
 variable_prev_temp: 220
-variable_unload_distance:  55
+variable_unload_distance:  90
 variable_purge_distance:  15
 gcode:
   {% set target_temp = prev_temp|int if prev_temp >= 200 else 220 %}


### PR DESCRIPTION
Maybe this is just me having things configured incorrectly elsewhere, or it's intended functionality, but I've always had to use the load/unload macros multiple times to fully load/unload filament.
For that reason, I've just upped the load/unload distance. Works well on my Neptune 4