### PR TITLE
fix(418): Target temp not restored after filament runout

### DIFF
--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -210,10 +210,8 @@ insert_gcode:
   M117 Insert Detected
 runout_gcode:
   M117 Runout Detected
-
-  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer.extruder.target|int}
-  SET_GCODE_VARIABLE MACRO=UNLOAD_FILAMENT VARIABLE=prev_temp VALUE={printer.extruder.target|int}
-  SET_GCODE_VARIABLE MACRO=LOAD_FILAMENT VARIABLE=prev_temp VALUE={printer.extruder.target|int}
+  SET_GCODE_VARIABLE MACRO=LOAD_FILAMENT VARIABLE=prev_temp VALUE={printer["gcode_macro RESUME"].etemp|int}
+  SET_GCODE_VARIABLE MACRO=UNLOAD_FILAMENT VARIABLE=prev_temp VALUE={printer["gcode_macro RESUME"].etemp|int}
   UNLOAD_FILAMENT
 event_delay: 3.0
 pause_delay: 1.0

--- a/printer-confs/base.cfg
+++ b/printer-confs/base.cfg
@@ -210,7 +210,10 @@ insert_gcode:
   M117 Insert Detected
 runout_gcode:
   M117 Runout Detected
+
+  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer.extruder.target|int}
   SET_GCODE_VARIABLE MACRO=UNLOAD_FILAMENT VARIABLE=prev_temp VALUE={printer.extruder.target|int}
+  SET_GCODE_VARIABLE MACRO=LOAD_FILAMENT VARIABLE=prev_temp VALUE={printer.extruder.target|int}
   UNLOAD_FILAMENT
 event_delay: 3.0
 pause_delay: 1.0


### PR DESCRIPTION
Add gcode variables similar to what PAUSE macro uses, to restore target temperature after loading and resuming after filament runout.

Fixes #418 