### PR TITLE
Add CI smoke tests and optional Klipper host sandbox

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,29 @@
+name: Smoke
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Scripts and generated configs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Run smoke tests
+        run: bash tests/smoke.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /display/venv/
 /display/__pycache__/
 /printer-confs/output.cfg
+__pycache__/
+.pytest_cache/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,153 @@
+# Tests and host sandbox
+
+This folder has two jobs:
+
+1. **CI / laptop smoke tests** — syntax and generated `printer.cfg` checks. No hardware.
+2. **Host sandbox** — an Ubuntu or Raspberry Pi box that runs the Klipper *host* stack so we can test scripts, macros, and Fluidd without the Neptune 4 Max.
+
+## What the sandbox is
+
+The Max is three machines: Linux host (RK3328), STM32 motion MCU, and real heaters / probe / TMC drivers.
+
+A Parallels Ubuntu ARM64 VM, or a Pi 4 / Pi 5, can stand in for the **Linux host only**. Same job as the board’s Armbian side: Klipper, Moonraker, Fluidd, `generate_conf.py`, installer scripts.
+
+It cannot emulate:
+
+- STM32 pins (`PC14`, `PA7`, …)
+- Sensorless homing / StallGuard
+- The bed probe, heaters, or input shaper
+- The OpenNept4une Armbian image (that image is for the ZNP-K1)
+
+Do not flash the OpenNept4une `.img` into Parallels. Do not use an `amd64` Ubuntu ISO on Apple Silicon.
+
+## Smoke tests (laptop or CI)
+
+From the repo root:
+
+```bash
+bash tests/smoke.sh
+```
+
+That checks:
+
+- `bash -n` on every `.sh` file
+- `shellcheck --severity=error` when installed
+- installer paths referenced by `OpenNept4une.sh`
+- `OpenNept4une.sh --help` (needs GNU `getopt`, i.e. Linux)
+- `generate_conf.py` for N4 0.8/1.2, N4 Pro 0.8/1.2, Plus, and Max
+
+GitHub Actions runs the same script from `.github/workflows/smoke.yml`.
+
+## Parallels VM (Apple Silicon)
+
+This is the path used for `OpenNept4une-pi` on an M1/M2/M3/M4 Mac.
+
+### Create the VM
+
+```bash
+prlctl create OpenNept4une-pi -o linux -d ubuntu
+prlctl set OpenNept4une-pi --cpus 4 --memsize 4096 --autostart off
+```
+
+Use ARM64 Ubuntu Server. A Pi 4/5 class box is 4 cores / 4 GB. The virtual disk can stay at 64 GB **expanding** — Parallels does not consume 64 GB on the Mac until the guest writes data.
+
+ISO (ARM64 server, not desktop, not amd64):
+
+```text
+https://cdimage.ubuntu.com/ubuntu/releases/24.04.3/release/ubuntu-24.04.3-live-server-arm64.iso
+```
+
+Attach and boot:
+
+```bash
+prlctl set OpenNept4une-pi --device-set cdrom0 \
+  --image /path/to/ubuntu-24.04.3-live-server-arm64.iso --connect
+prlctl start OpenNept4une-pi
+```
+
+### Ubuntu installer choices
+
+Pick **Ubuntu Server**, not **Ubuntu Server (minimized)**. Minimized drops tools Kiauh / Klipper / compilers expect. Disk space is not the constraint here.
+
+| Screen | Choice |
+|---|---|
+| Language / keyboard | Your locale |
+| Install type | **Ubuntu Server** (not minimized) |
+| Network | Keep DHCP on `enp0s5`. Do **not** create a bond. Parallels typically assigns `10.211.55.x` |
+| Proxy | Empty unless you need one |
+| Mirror | Default |
+| Disk | Use the **whole** 64 GB virtual disk. Default LVM/ext4 is fine |
+| Hostname | `opennept4une-pi` |
+| Username | `mks` |
+| OpenSSH | **Install** |
+| Featured snaps | **None**. Leave every snap unchecked |
+| Desktop | Do not install one |
+
+`10.211.55.x` is the address the Mac browser will use for Fluidd. It can change after reboot until you add a DHCP reservation.
+
+After the installer reboots, log in and install Parallels Tools from the Parallels menu so `prlctl exec` and shared folders work.
+
+## Raspberry Pi instead of Parallels
+
+Use a **Pi 4 or Pi 5**. Skip Pi 2 and Pi Zero for Moonraker + Fluidd.
+
+Install Raspberry Pi OS 64-bit (or Ubuntu Server 24.04 ARM64), enable SSH, then run `tests/setup.sh` the same way.
+
+## Provision the host stack
+
+On the new Ubuntu/Pi user (after first boot):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y git
+git clone https://github.com/OpenNeptune3D/OpenNept4une.git ~/OpenNept4une
+cd ~/OpenNept4une
+sudo ./tests/setup.sh
+```
+
+`setup.sh` is safe to re-run. It:
+
+- refuses to run on a real OpenNept4une printer image unless you pass `--force`
+- installs apt packages needed to build Klipper and the Linux process MCU
+- clones Klipper, Moonraker, Fluidd, KAMP, and Kiauh
+- runs the upstream Klipper / Moonraker installers
+- installs Fluidd behind nginx on port 80
+- generates every model `printer.cfg` into `~/printer_data/config/generated/`
+- installs a **sandbox** `printer.cfg` that talks to the Linux process MCU, not `/dev/ttyS0`
+
+Open Fluidd at `https://<guest-ip>/` (Parallels example: `https://10.211.55.11/`). Moonraker stays on port `7125` behind nginx.
+
+HTTPS uses a **self-signed** certificate. Let's Encrypt cannot sign a Parallels `10.211.55.x` address. The browser will warn; click Advanced → Proceed.
+
+To add HTTPS to an already-provisioned sandbox:
+
+```bash
+sudo ./tests/enable-https.sh
+```
+
+To trust the cert on the Mac after that:
+
+```bash
+scp mks@10.211.55.11:/etc/ssl/opennept4une/opennept4une.crt /tmp/opennept4une.crt
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain /tmp/opennept4une.crt
+```
+
+Kiauh is left in `~/kiauh` for later interactive updates. It is not required for the first boot.
+
+## What you can test here vs on the printer
+
+**On the sandbox**
+
+- `tests/smoke.sh` and `generate_conf.py`
+- Fluidd / Moonraker / Orca network upload
+- Jinja macros that do not need a real toolhead
+- Installer script edits (`bash -n`, `--help`)
+
+**On the Max only**
+
+- Homing, mesh, Z-offset, PID, pressure advance, input shaper
+- MCU `.bin` flashes
+- Heat-soak and first-layer
+
+Keep live printer overrides in `user_settings.cfg`. Do not treat sandbox motion values as calibrated Max values.

--- a/tests/enable-https.sh
+++ b/tests/enable-https.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Enable HTTPS for Fluidd/Moonraker via nginx and a local certificate.
+# Let's Encrypt cannot sign 10.211.55.x / LAN IPs. This uses a self-signed cert
+# with IP and hostname SANs. Browsers will warn until you trust the cert.
+set -euo pipefail
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "Error: run with sudo:  sudo $0" >&2
+    exit 1
+fi
+
+die() { echo "Error: $*" >&2; exit 1; }
+ok() { echo "==> $*"; }
+
+TARGET_USER="${SUDO_USER:-mks}"
+if [[ "$TARGET_USER" = "root" ]]; then
+    TARGET_USER="mks"
+fi
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6 || true)"
+[[ -n "$TARGET_HOME" ]] || TARGET_HOME="/home/${TARGET_USER}"
+FLUIDD_DIR="${FLUIDD_DIR:-${TARGET_HOME}/fluidd}"
+[[ -d "$FLUIDD_DIR" ]] || die "Fluidd not found at ${FLUIDD_DIR}"
+
+CERT_DIR="${CERT_DIR:-/etc/ssl/opennept4une}"
+CERT="${CERT_DIR}/opennept4une.crt"
+KEY="${CERT_DIR}/opennept4une.key"
+DAYS="${CERT_DAYS:-825}"
+REDIRECT_HTTP="${REDIRECT_HTTP:-true}"
+
+hostname_fqdn="$(hostname -f 2>/dev/null || hostname)"
+hostname_short="$(hostname)"
+mapfile -t ipv4s < <(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' || true)
+
+ok "Creating certificate in ${CERT_DIR}"
+mkdir -p "$CERT_DIR"
+chmod 755 "$CERT_DIR"
+
+san="DNS:localhost,DNS:${hostname_short},DNS:${hostname_fqdn},IP:127.0.0.1"
+for ip in "${ipv4s[@]+"${ipv4s[@]}"}"; do
+    [[ -n "$ip" ]] || continue
+    san="${san},IP:${ip}"
+done
+
+tmp_cfg="$(mktemp)"
+cat > "$tmp_cfg" <<EOF
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = ${hostname_short}
+O = OpenNept4une sandbox
+
+[v3_req]
+subjectAltName = ${san}
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+basicConstraints = CA:false
+EOF
+
+openssl req -x509 -nodes -days "$DAYS" -newkey rsa:2048 \
+    -keyout "$KEY" \
+    -out "$CERT" \
+    -config "$tmp_cfg"
+rm -f "$tmp_cfg"
+chmod 640 "$KEY"
+chmod 644 "$CERT"
+chown root:www-data "$KEY" || chown root:root "$KEY"
+
+ok "Writing nginx TLS site (SAN: ${san})"
+http_block=""
+if [[ "$REDIRECT_HTTP" = "true" ]]; then
+    http_block=$(cat <<'HTTP'
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+HTTP
+)
+else
+    http_block=$(cat <<HTTP
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    root ${FLUIDD_DIR};
+    index index.html;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+
+    location /websocket {
+        proxy_pass http://127.0.0.1:7125/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+    }
+
+    location ~ ^/(printer|api|access|machine|server)/ {
+        proxy_pass http://127.0.0.1:7125\$request_uri;
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+}
+HTTP
+)
+fi
+
+cat > /etc/nginx/sites-available/fluidd <<EOF
+${http_block}
+
+server {
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
+    server_name _;
+    root ${FLUIDD_DIR};
+    index index.html;
+
+    ssl_certificate ${CERT};
+    ssl_certificate_key ${KEY};
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+
+    location /websocket {
+        proxy_pass http://127.0.0.1:7125/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+        proxy_read_timeout 86400;
+    }
+
+    location ~ ^/(printer|api|access|machine|server)/ {
+        proxy_pass http://127.0.0.1:7125\$request_uri;
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_read_timeout 86400;
+    }
+}
+EOF
+
+rm -f /etc/nginx/sites-enabled/default
+ln -sfn /etc/nginx/sites-available/fluidd /etc/nginx/sites-enabled/fluidd
+nginx -t
+systemctl reload nginx
+
+moon_conf="${TARGET_HOME}/printer_data/config/moonraker.conf"
+if [[ -f "$moon_conf" ]]; then
+    ok "Ensuring Moonraker CORS allows https for this host"
+    extra=("*://localhost" "*://localhost:*" "*://${hostname_short}" "*://${hostname_fqdn}")
+    for ip in "${ipv4s[@]+"${ipv4s[@]}"}"; do
+        [[ -n "$ip" ]] || continue
+        extra+=("*://${ip}" "*://${ip}:*")
+    done
+    for origin in "${extra[@]}"; do
+        if ! grep -Fq "$origin" "$moon_conf"; then
+            awk -v orig="$origin" '
+                BEGIN { added=0 }
+                { print }
+                $0 ~ /^cors_domains:/ && !added { print "    " orig; added=1 }
+            ' "$moon_conf" > "${moon_conf}.tmp"
+            mv "${moon_conf}.tmp" "$moon_conf"
+        fi
+    done
+    chown "${TARGET_USER}:${TARGET_USER}" "$moon_conf"
+    systemctl restart moonraker.service || true
+fi
+
+primary_ip="${ipv4s[0]:-localhost}"
+echo
+ok "HTTPS is enabled"
+echo "Open:  https://${primary_ip}/"
+echo "Cert:  ${CERT}"
+echo
+echo "The browser will warn because this is a self-signed cert (Let's Encrypt"
+echo "cannot sign a Parallels 10.211.55.x address). Click Advanced → Proceed."
+echo
+echo "To trust it on the Mac (one time):"
+echo "  scp ${TARGET_USER}@${primary_ip}:${CERT} /tmp/opennept4une.crt"
+echo "  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/opennept4une.crt"

--- a/tests/sandbox-moonraker.conf
+++ b/tests/sandbox-moonraker.conf
@@ -1,0 +1,54 @@
+[server]
+host: 0.0.0.0
+port: 7125
+klippy_uds_address: /home/mks/printer_data/comms/klippy.sock
+
+[authorization]
+trusted_clients:
+    10.10.0.0/16
+    10.0.0.0/8
+    127.0.0.0/8
+    169.254.0.0/16
+    172.16.0.0/12
+    192.168.0.0/16
+    FE80::/10
+    ::1/128
+cors_domains:
+    *.lan
+    *.local
+    *://localhost
+    *://localhost:*
+    *://my.mainsail.xyz
+    *://app.fluidd.xyz
+
+[file_manager]
+enable_object_processing: True
+
+[octoprint_compat]
+
+[history]
+
+[update_manager]
+channel: dev
+refresh_interval: 168
+
+[update_manager fluidd]
+type: web
+channel: stable
+repo: fluidd-core/fluidd
+path: ~/fluidd
+
+[update_manager Klipper-Adaptive-Meshing-Purging]
+type: git_repo
+channel: dev
+path: ~/Klipper-Adaptive-Meshing-Purging
+origin: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging.git
+managed_services: klipper
+primary_branch: main
+
+[update_manager OpenNept4une]
+type: git_repo
+primary_branch: main
+path: /home/mks/OpenNept4une
+is_system_service: False
+origin: https://github.com/OpenNeptune3D/OpenNept4une.git

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Provision an Ubuntu Server or Raspberry Pi host sandbox for OpenNept4une.
+# This is the Klipper/Moonraker/Fluidd host only. It is not the printer MCU.
+set -euo pipefail
+
+FORCE="false"
+SKIP_APT="false"
+
+usage() {
+    cat <<'EOF'
+Usage: sudo ./tests/setup.sh [OPTIONS]
+
+Install Klipper, Moonraker, Fluidd, KAMP, and generated OpenNept4une configs
+on an Ubuntu/Pi host sandbox (Parallels ARM64 VM or Raspberry Pi 4/5).
+
+Options:
+  --force      Allow running on a real OpenNept4une printer image
+  --skip-apt   Skip apt-get update/install (re-run after packages exist)
+  -h, --help   Show this help
+
+Run as a normal user via sudo, not as a login root shell:
+  sudo ./tests/setup.sh
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force) FORCE="true"; shift ;;
+        --skip-apt) SKIP_APT="true"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "Error: run with sudo:  sudo $0" >&2
+    exit 1
+fi
+if [[ -z "${SUDO_USER:-}" || "${SUDO_USER}" = "root" ]]; then
+    echo "Error: do not run as plain root. Run via sudo from your normal user." >&2
+    exit 1
+fi
+
+die() { echo "Error: $*" >&2; exit 1; }
+ok() { echo "==> $*"; }
+
+if [[ -f /boot/.OpenNept4une.txt && "$FORCE" != "true" ]]; then
+    die "Refusing to run on an OpenNept4une printer image. Pass --force if you meant to."
+fi
+
+TARGET_USER="${SUDO_USER}"
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+[[ -n "$TARGET_HOME" ]] || die "Cannot resolve home for $TARGET_USER"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/../printer-confs/generate_conf.py" ]]; then
+    REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+    REPO_DIR="${TARGET_HOME}/OpenNept4une"
+fi
+
+OPENNEPT4UNE_REPO="${OPENNEPT4UNE_REPO:-https://github.com/OpenNeptune3D/OpenNept4une.git}"
+KLIPPER_REPO="${KLIPPER_REPO:-https://github.com/Klipper3d/klipper.git}"
+MOONRAKER_REPO="${MOONRAKER_REPO:-https://github.com/Arksine/moonraker.git}"
+KAMP_REPO="${KAMP_REPO:-https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging.git}"
+KIAUH_REPO="${KIAUH_REPO:-https://github.com/dw-0/kiauh.git}"
+FLUIDD_ZIP="${FLUIDD_ZIP:-https://github.com/fluidd-core/fluidd/releases/latest/download/fluidd.zip}"
+
+KLIPPER_DIR="${TARGET_HOME}/klipper"
+MOONRAKER_DIR="${TARGET_HOME}/moonraker"
+FLUIDD_DIR="${TARGET_HOME}/fluidd"
+KAMP_DIR="${TARGET_HOME}/Klipper-Adaptive-Meshing-Purging"
+KIAUH_DIR="${TARGET_HOME}/kiauh"
+PDIR="${TARGET_HOME}/printer_data"
+PCONFIG="${PDIR}/config"
+PLOGS="${PDIR}/logs"
+PGEN="${PCONFIG}/generated"
+
+as_user() {
+    sudo -u "$TARGET_USER" --preserve-env=HOME env HOME="$TARGET_HOME" "$@"
+}
+
+clone_or_update() {
+    local url="$1" dest="$2"
+    if [[ -d "${dest}/.git" ]]; then
+        ok "Updating ${dest}"
+        as_user git -C "$dest" pull --ff-only || true
+    else
+        ok "Cloning ${url}"
+        as_user git clone --depth=1 "$url" "$dest"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [[ "$SKIP_APT" != "true" ]]; then
+    ok "Installing apt packages"
+    apt-get update
+    apt-get install -y \
+        git wget curl unzip sudo \
+        python3 python3-venv python3-dev python3-pip \
+        build-essential libffi-dev libncurses-dev libusb-dev \
+        libjpeg-dev zlib1g-dev \
+        pkg-config virtualenv \
+        nginx \
+        stm32flash dfu-util \
+        gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi \
+        libopenblas-dev python3-numpy
+fi
+
+if [[ ! -f "${REPO_DIR}/printer-confs/generate_conf.py" ]]; then
+    clone_or_update "$OPENNEPT4UNE_REPO" "$REPO_DIR"
+fi
+
+clone_or_update "$KLIPPER_REPO" "$KLIPPER_DIR"
+clone_or_update "$MOONRAKER_REPO" "$MOONRAKER_DIR"
+clone_or_update "$KAMP_REPO" "$KAMP_DIR"
+clone_or_update "$KIAUH_REPO" "$KIAUH_DIR"
+
+ok "Ensuring printer_data layout"
+as_user mkdir -p "$PCONFIG" "$PLOGS" "${PDIR}/gcodes" "${PDIR}/database" "${PDIR}/comms" "$PGEN"
+if [[ ! -L "${PCONFIG}/KAMP" ]]; then
+    as_user ln -sfn "${KAMP_DIR}/Configuration" "${PCONFIG}/KAMP"
+fi
+
+if [[ ! -x "${TARGET_HOME}/klippy-env/bin/python" ]]; then
+    ok "Installing Klipper"
+    if [[ -x "${KLIPPER_DIR}/scripts/install-ubuntu-22.04.sh" ]]; then
+        as_user bash "${KLIPPER_DIR}/scripts/install-ubuntu-22.04.sh"
+    else
+        die "Klipper install script not found"
+    fi
+else
+    ok "Klipper venv already present; skipping installer"
+fi
+
+if [[ ! -f "${PCONFIG}/moonraker.conf" ]]; then
+    ok "Writing sandbox moonraker.conf"
+    src_moon="${REPO_DIR}/tests/sandbox-moonraker.conf"
+    [[ -f "$src_moon" ]] || src_moon="${REPO_DIR}/img-config/printer-data/moonraker.conf"
+    sed "s|/home/mks|${TARGET_HOME}|g" "$src_moon" > "${PCONFIG}/moonraker.conf"
+    chown "${TARGET_USER}:${TARGET_USER}" "${PCONFIG}/moonraker.conf"
+fi
+
+if [[ ! -x "${TARGET_HOME}/moonraker-env/bin/python" ]]; then
+    ok "Installing Moonraker"
+    as_user bash "${MOONRAKER_DIR}/scripts/install-moonraker.sh" \
+        -d "${PDIR}" \
+        -c "${PCONFIG}/moonraker.conf" \
+        -l "${PLOGS}/moonraker.log"
+else
+    ok "Moonraker venv already present; skipping installer"
+fi
+
+ok "Installing Fluidd"
+as_user mkdir -p "$FLUIDD_DIR"
+if [[ ! -f "${FLUIDD_DIR}/index.html" ]]; then
+    tmpzip="$(as_user mktemp "${TARGET_HOME}/fluidd.XXXXXX.zip")"
+    as_user wget -O "$tmpzip" "$FLUIDD_ZIP" || die "Fluidd download failed"
+    [[ -s "$tmpzip" ]] || die "Fluidd download was empty"
+    as_user unzip -t "$tmpzip" >/dev/null || die "Fluidd zip is not valid"
+    as_user unzip -qo "$tmpzip" -d "$FLUIDD_DIR"
+    rm -f "$tmpzip"
+    [[ -f "${FLUIDD_DIR}/index.html" ]] || die "Fluidd extract did not produce index.html"
+else
+    ok "Fluidd already present; skipping download"
+fi
+chown -R "${TARGET_USER}:${TARGET_USER}" "$FLUIDD_DIR"
+# nginx (www-data) must be able to traverse the home directory
+chmod 755 "$TARGET_HOME"
+
+ok "Configuring nginx for Fluidd"
+cat > /etc/nginx/sites-available/fluidd <<EOF
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    root ${FLUIDD_DIR};
+    index index.html;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+
+    location /websocket {
+        proxy_pass http://127.0.0.1:7125/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$http_host;
+    }
+
+    location ~ ^/(printer|api|access|machine|server)/ {
+        proxy_pass http://127.0.0.1:7125\$request_uri;
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+}
+EOF
+rm -f /etc/nginx/sites-enabled/default
+ln -sfn /etc/nginx/sites-available/fluidd /etc/nginx/sites-enabled/fluidd
+nginx -t
+systemctl enable nginx
+systemctl restart nginx
+
+if [[ -x "${SCRIPT_DIR}/enable-https.sh" ]]; then
+    ok "Enabling HTTPS"
+    bash "${SCRIPT_DIR}/enable-https.sh" || echo "Warning: HTTPS setup failed; HTTP still works"
+fi
+
+ok "Building Linux process MCU"
+if [[ -f "${REPO_DIR}/mcu-firmware/virtualmcu.config" ]]; then
+    as_user cp "${REPO_DIR}/mcu-firmware/virtualmcu.config" "${KLIPPER_DIR}/.config"
+    as_user make -C "$KLIPPER_DIR" olddefconfig
+    as_user make -C "$KLIPPER_DIR" -j"$(nproc)"
+    make -C "$KLIPPER_DIR" flash || echo "Warning: virtual MCU flash/install failed; continuing"
+    if [[ -f "${KLIPPER_DIR}/scripts/klipper-mcu.service" ]]; then
+        cp "${KLIPPER_DIR}/scripts/klipper-mcu.service" /etc/systemd/system/klipper-mcu.service
+        systemctl daemon-reload
+        systemctl enable klipper-mcu.service || true
+        systemctl restart klipper-mcu.service || true
+    fi
+fi
+
+ok "Generating OpenNept4une printer configs"
+as_user python3 "${REPO_DIR}/printer-confs/generate_conf.py" n4 0.8
+as_user cp "${REPO_DIR}/printer-confs/output.cfg" "${PGEN}/n4-0.8.cfg"
+as_user python3 "${REPO_DIR}/printer-confs/generate_conf.py" n4 1.2
+as_user cp "${REPO_DIR}/printer-confs/output.cfg" "${PGEN}/n4-1.2.cfg"
+as_user python3 "${REPO_DIR}/printer-confs/generate_conf.py" n4pro 0.8
+as_user cp "${REPO_DIR}/printer-confs/output.cfg" "${PGEN}/n4pro-0.8.cfg"
+as_user python3 "${REPO_DIR}/printer-confs/generate_conf.py" n4pro 1.2
+as_user cp "${REPO_DIR}/printer-confs/output.cfg" "${PGEN}/n4pro-1.2.cfg"
+as_user python3 "${REPO_DIR}/printer-confs/generate_conf.py" n4plus
+as_user cp "${REPO_DIR}/printer-confs/output.cfg" "${PGEN}/n4plus.cfg"
+as_user python3 "${REPO_DIR}/printer-confs/generate_conf.py" n4max
+as_user cp "${REPO_DIR}/printer-confs/output.cfg" "${PGEN}/n4max.cfg"
+
+if [[ ! -f "${PCONFIG}/user_settings.cfg" ]]; then
+    as_user tee "${PCONFIG}/user_settings.cfg" >/dev/null <<'EOF'
+# Sandbox-only overrides. On a real printer this file is yours to keep
+# across OpenNept4une printer.cfg regenerations.
+EOF
+fi
+
+if [[ ! -f "${PCONFIG}/printer.cfg" ]]; then
+    ok "Writing sandbox printer.cfg (Linux MCU, not the Max STM32)"
+    as_user tee "${PCONFIG}/printer.cfg" >/dev/null <<'EOF'
+# Host-sandbox printer.cfg
+# Generated configs for the real Max/Plus/Pro live in generated/.
+# This file only has to start klippy on a VM or Pi with no STM32.
+
+[include user_settings.cfg]
+
+[mcu]
+serial: /tmp/klipper_host_mcu
+
+[virtual_sdcard]
+path: ~/printer_data/gcodes
+
+[display_status]
+[pause_resume]
+[respond]
+[force_move]
+enable_force_move: True
+
+[printer]
+kinematics: cartesian
+max_velocity: 250
+max_accel: 3000
+max_z_velocity: 8
+max_z_accel: 120
+
+[stepper_x]
+step_pin: gpiochip0/gpio0
+dir_pin: gpiochip0/gpio1
+enable_pin: !gpiochip0/gpio2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: gpiochip0/gpio3
+position_endstop: 0
+position_max: 430
+homing_speed: 50
+
+[stepper_y]
+step_pin: gpiochip0/gpio4
+dir_pin: gpiochip0/gpio5
+enable_pin: !gpiochip0/gpio6
+microsteps: 16
+rotation_distance: 40
+endstop_pin: gpiochip0/gpio7
+position_endstop: 0
+position_max: 430
+homing_speed: 50
+
+[stepper_z]
+step_pin: gpiochip0/gpio8
+dir_pin: gpiochip0/gpio9
+enable_pin: !gpiochip0/gpio10
+microsteps: 16
+rotation_distance: 8
+endstop_pin: gpiochip0/gpio11
+position_endstop: 0
+position_max: 505
+
+[extruder]
+step_pin: gpiochip0/gpio12
+dir_pin: gpiochip0/gpio13
+enable_pin: !gpiochip0/gpio14
+microsteps: 16
+rotation_distance: 28.888
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: gpiochip0/gpio15
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: gpiochip0/gpio16
+control: pid
+pid_kp: 25.718
+pid_ki: 3.297
+pid_kd: 50.150
+min_temp: 0
+max_temp: 330
+EOF
+fi
+
+chown -R "${TARGET_USER}:${TARGET_USER}" "$PDIR"
+# The stock Klipper unit reads ~/printer.cfg, not printer_data/config/printer.cfg
+ln -sfn "${PCONFIG}/printer.cfg" "${TARGET_HOME}/printer.cfg"
+ln -sfn "${PCONFIG}/user_settings.cfg" "${TARGET_HOME}/user_settings.cfg"
+chown -h "${TARGET_USER}:${TARGET_USER}" "${TARGET_HOME}/printer.cfg" "${TARGET_HOME}/user_settings.cfg"
+
+systemctl enable klipper.service 2>/dev/null || true
+systemctl enable moonraker.service 2>/dev/null || true
+systemctl restart klipper.service 2>/dev/null || true
+systemctl restart moonraker.service 2>/dev/null || true
+
+ip_addr="$(hostname -I 2>/dev/null | awk '{print $1}')"
+ok "Host sandbox provisioned"
+echo
+echo "Fluidd:    http://${ip_addr:-GUEST-IP}/"
+echo "Moonraker: http://${ip_addr:-GUEST-IP}:7125/"
+echo "Generated Max config: ${PGEN}/n4max.cfg"
+echo "Active printer.cfg is a Linux-MCU sandbox, not the STM32 Max config."
+echo "Kiauh (optional): ${KIAUH_DIR}/kiauh.sh"
+echo
+echo "If klippy cannot claim gpiochip0 pins, that is expected on some VMs."
+echo "Fluidd/Moonraker and generated/*.cfg are still usable for config work."

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Local + CI smoke checks for scripts and generated printer configs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+ok() { printf 'OK: %s\n' "$*"; }
+
+echo "== Python syntax =="
+python3 -m py_compile "$ROOT/printer-confs/generate_conf.py"
+ok "printer-confs/generate_conf.py compiles"
+
+echo "== Shell syntax (bash -n) =="
+scripts=()
+while IFS= read -r script; do
+    scripts+=("$script")
+done < <(find "$ROOT" -name '*.sh' -not -path "$ROOT/.git/*" | sort)
+[[ ${#scripts[@]} -gt 0 ]] || fail "no shell scripts found"
+for script in "${scripts[@]}"; do
+    bash -n "$script" || fail "bash -n $script"
+done
+ok "${#scripts[@]} scripts passed bash -n"
+
+echo "== Referenced installer scripts exist =="
+referenced=(
+    "$ROOT/OpenNept4une.sh"
+    "$ROOT/img-config/rpi-mcu-install.sh"
+    "$ROOT/img-config/usb-storage-automount.sh"
+    "$ROOT/img-config/adb-automount.sh"
+    "$ROOT/img-config/webcam-setup.sh"
+    "$ROOT/img-config/base_image_configuration.sh"
+    "$ROOT/img-config/update-ssh-keys.sh"
+    "$ROOT/img-config/set-printer-model.sh"
+    "$ROOT/img-config/github-issue-debug.sh"
+    "$ROOT/img-config/power_monitor.sh"
+    "$ROOT/mcu-firmware/alt-method/mcu-swflash-run.sh"
+    "$ROOT/mcu-firmware/alt-method/mcu-swflash-install.sh"
+    "$ROOT/tests/setup.sh"
+    "$ROOT/tests/enable-https.sh"
+    "$ROOT/tests/smoke.sh"
+)
+for path in "${referenced[@]}"; do
+    [[ -f "$path" ]] || fail "missing referenced script: $path"
+    [[ -s "$path" ]] || fail "empty referenced script: $path"
+done
+ok "${#referenced[@]} installer paths exist"
+
+echo "== OpenNept4une.sh --help =="
+if getopt -T >/dev/null 2>&1; then
+    getopt_rc=$?
+else
+    getopt_rc=$?
+fi
+# GNU getopt -T returns 4
+if [[ "$getopt_rc" -eq 4 ]]; then
+    help_out="$(bash "$ROOT/OpenNept4une.sh" --help)"
+    printf '%s\n' "$help_out" | grep -q 'Usage:' || fail "help missing Usage:"
+    printf '%s\n' "$help_out" | grep -q 'install_printer_cfg' || fail "help missing install_printer_cfg"
+    ok "OpenNept4une.sh --help"
+else
+    echo "SKIP: GNU getopt not available (needed for --help parsing)"
+fi
+
+if command -v shellcheck >/dev/null 2>&1; then
+    echo "== shellcheck (errors only) =="
+    shellcheck --severity=error --shell=bash "${scripts[@]}"
+    ok "shellcheck --severity=error"
+else
+    echo "SKIP: shellcheck not installed"
+fi
+
+echo "== generate_conf unit tests =="
+python3 -m unittest discover -s "$ROOT/tests" -p 'test_*.py' -v
+ok "unittest suite"
+
+echo
+echo "All smoke checks passed."

--- a/tests/test_generate_conf.py
+++ b/tests/test_generate_conf.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke tests for printer-confs/generate_conf.py."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import Optional
+
+REPO = Path(__file__).resolve().parents[1]
+CONF_DIR = REPO / "printer-confs"
+OUTPUT_CFG = CONF_DIR / "output.cfg"
+
+if str(CONF_DIR) not in sys.path:
+    sys.path.insert(0, str(CONF_DIR))
+
+import generate_conf  # noqa: E402
+
+
+PLACEHOLDER_RE = re.compile(r"\{\{\s*\w+\s*\}\}")
+
+MODELS = (
+    ("n4", "0.8"),
+    ("n4", "1.2"),
+    ("n4pro", "0.8"),
+    ("n4pro", "1.2"),
+    ("n4plus", None),
+    ("n4max", None),
+)
+
+
+def generate(model: str, current: Optional[str]) -> str:
+    if OUTPUT_CFG.exists():
+        OUTPUT_CFG.unlink()
+    with contextlib.redirect_stdout(io.StringIO()):
+        generate_conf.generate_conf(model, current)
+    return OUTPUT_CFG.read_text(encoding="utf-8")
+
+
+class GenerateConfSmoke(unittest.TestCase):
+    def test_cli_requires_model(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CONF_DIR / "generate_conf.py")],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Usage:", result.stdout + result.stderr)
+
+    def test_cli_rejects_unknown_model(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CONF_DIR / "generate_conf.py"), "not-a-model"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ERROR:", result.stdout + result.stderr)
+
+    def test_all_supported_models_generate(self) -> None:
+        for model, current in MODELS:
+            with self.subTest(model=model, current=current):
+                text = generate(model, current)
+                self.assertTrue(text.strip(), f"{model} produced an empty config")
+                leftover = PLACEHOLDER_RE.findall(text)
+                self.assertEqual(leftover, [], f"{model} left placeholders: {leftover}")
+                self.assertIn("[printer]", text)
+                self.assertIn("[gcode_macro PRINT_START]", text)
+                self.assertIn("[include user_settings.cfg]", text)
+                self.assertIn(f"printer_model: {model}", text.splitlines()[0])
+
+    def test_n4max_bounds(self) -> None:
+        text = generate("n4max", None)
+        self.assertIn("position_max: 430", text)
+        self.assertIn("position_max: 505", text)
+        self.assertIn("mesh_max: 397,404", text)
+        self.assertIn("x_offset: -24.25", text)
+        self.assertIn("y_offset: 20.45", text)
+        self.assertIn("home_xy_position: 239.75,194.55", text)
+        self.assertIn("calibrate_start_x: 25", text)
+        self.assertIn("calibrate_end_x: 395", text)
+        self.assertIn("run_current: 1.0", text)
+        self.assertIn("run_current: 1.3", text)
+        self.assertIn("driver_SGTHRS: 90", text)
+        self.assertIn("driver_SGTHRS: 80", text)
+        self.assertIn("BED_HEAT_SOAK_MINUTES", text)
+        self.assertNotIn("heater_bed_outer", text)
+
+    def test_n4plus_bounds(self) -> None:
+        text = generate("n4plus", None)
+        self.assertIn("position_max: 330", text)
+        self.assertIn("position_max: 405", text)
+        self.assertIn("run_current: 1.1", text)
+        self.assertNotIn("heater_bed_outer", text)
+
+    def test_n4_and_n4pro_currents(self) -> None:
+        n4_08 = generate("n4", "0.8")
+        self.assertIn("position_max: 235", n4_08)
+        self.assertIn("run_current: 0.8", n4_08)
+        self.assertNotIn("heater_bed_outer", n4_08)
+
+        n4_12 = generate("n4", "1.2")
+        self.assertIn("run_current: 1.2", n4_12)
+
+        n4pro = generate("n4pro", "0.8")
+        self.assertIn("[heater_generic heater_bed_outer]", n4pro)
+        self.assertIn("variable_small_print", n4pro)
+        self.assertIn("PID_Tune_Outer_BED", n4pro)
+
+    def test_missing_override_exits(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CONF_DIR / "generate_conf.py"), "n4max", "1.2"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ERROR:", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds host-side tests that do not need a printer, plus optional scripts to stand up a Klipper/Moonraker/Fluidd sandbox on Ubuntu or a Pi 4/5.

This is ready as a **dev-tools PR**. It does not change `printer-confs/` motion configs or MCU firmware.

![image](https://github.com/user-attachments/assets/2af346a3-ecf8-4cf4-bb32-cff553663dad)


## Why

`generate_conf.py` and the installer scripts are easy to break without noticing. A VM can exercise Fluidd/Moonraker/config generation, but not homing, mesh, PID, or STM32 flashes.

## What landed

- GitHub Actions `smoke.yml` runs `tests/smoke.sh` on push/PR
- `bash -n` + `shellcheck --severity=error` on all shell scripts
- `generate_conf.py` coverage for N4 0.8/1.2, N4 Pro 0.8/1.2, Plus, and Max (including Max mesh/probe/current bounds)
- `tests/setup.sh` provisions Klipper, Moonraker, Fluidd, KAMP, generated configs
- `tests/enable-https.sh` terminates TLS at nginx with a self-signed cert (Let's Encrypt cannot sign Parallels `10.211.55.x`)
- `tests/sandbox-moonraker.conf` omits Mainsail, Mobileraker, and display_connector so a sandbox does not warn about missing printer-image paths
- `tests/README.md` documents Parallels/Ubuntu Server vs Pi, and what still requires the Max

## Test plan

- [x] `bash tests/smoke.sh` on macOS (GNU getopt/shellcheck skipped, unittests passed)
- [x] Same suite intended for Ubuntu Actions
- [x] `setup.sh` on a Parallels Ubuntu 24.04 ARM64 VM (Fluidd + Moonraker up; Linux MCU GPIO not present, as documented)
- [x] `enable-https.sh` → `https://10.211.55.11/` returns 200
- [x] Trimmed Moonraker config clears update_manager warnings on the sandbox
- [x] Confirm Actions is green after this PR is opened

## Notes for reviewers

- `setup.sh` refuses to run on a real OpenNept4une image unless `--force` is passed.
- Do not copy `tests/sandbox-moonraker.conf` onto a printer; the image `moonraker.conf` still owns display/Mobileraker.
- Klippy will not go ready on Parallels (`GPIO chip device not found`). That is expected.